### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Idbsurvey/Form/Report/IDBReport.php
+++ b/CRM/Idbsurvey/Form/Report/IDBReport.php
@@ -188,7 +188,7 @@ class CRM_Idbsurvey_Form_Report_IDBReport extends CRM_Report_Form {
           $this->answers[10] = self::tsLocal('Yes:') . ' <ul><li>' . implode('</li><li>', $memberships['values']) . '</li></ul>';
         }
       }
-      catch (CiviCRM_API3_Exception $e) {
+      catch (CRM_Core_Exception $e) {
         $this->answers[10] = 'API Error: ' . $e->getMessage();
       }
     }

--- a/idbsurvey.php
+++ b/idbsurvey.php
@@ -67,7 +67,7 @@ function idbsurvey_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
       ),
     ));
   }
-  catch (CiviCRM_API3_Exception $e) {
+  catch (CRM_Core_Exception $e) {
     CRM_Core_Session::setStatus($e->getMessage(), ts('API Error', array('domain' => 'com.aghstrategies.idbsurvey')), 'error');
   }
 


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.